### PR TITLE
Cerrar menú pausa

### DIFF
--- a/BreakOut/Assets/Scenes/Nivel 1.unity
+++ b/BreakOut/Assets/Scenes/Nivel 1.unity
@@ -3835,6 +3835,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   menuPausa: {fileID: 10158744}
   pelotaPrefab: {fileID: 9164215006120764912, guid: 0989608047419bc43a8357d206e6a4fb, type: 3}
+  pelota: {fileID: 1994711649}
 --- !u!114 &963194233
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7070,6 +7071,17 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0989608047419bc43a8357d206e6a4fb, type: 3}
+--- !u!114 &1994711649 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1834984490, guid: 0989608047419bc43a8357d206e6a4fb, type: 3}
+  m_PrefabInstance: {fileID: 1994711648}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 030827d7ca3eacb408742948dcba43dd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1998445518
 GameObject:
   m_ObjectHideFlags: 0

--- a/BreakOut/Assets/Scenes/Nivel 2.unity
+++ b/BreakOut/Assets/Scenes/Nivel 2.unity
@@ -4257,6 +4257,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   menuPausa: {fileID: 10158744}
   pelotaPrefab: {fileID: 9164215006120764912, guid: 0989608047419bc43a8357d206e6a4fb, type: 3}
+  pelota: {fileID: 1865596688}
 --- !u!114 &963194233
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/BreakOut/Assets/Scenes/Nivel 3.unity
+++ b/BreakOut/Assets/Scenes/Nivel 3.unity
@@ -4417,6 +4417,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   menuPausa: {fileID: 10158744}
   pelotaPrefab: {fileID: 9164215006120764912, guid: 0989608047419bc43a8357d206e6a4fb, type: 3}
+  pelota: {fileID: 1865596688}
 --- !u!114 &963194233
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/BreakOut/Assets/Scripts/Bloque.cs
+++ b/BreakOut/Assets/Scripts/Bloque.cs
@@ -33,7 +33,6 @@ public class Bloque : MonoBehaviour
             //aumentarPuntaje.Invoke();
             AumentarScore();
             Destroy(this.gameObject);
-
         }
     }
 

--- a/BreakOut/Assets/Scripts/MenuPausa.cs
+++ b/BreakOut/Assets/Scripts/MenuPausa.cs
@@ -7,7 +7,7 @@ using UnityEngine.SceneManagement;
 public class MenuPausa : MonoBehaviour
 {
     public GameObject menuPausa, pelotaPrefab;
-    private Pelota pelotaScript;
+    public Pelota pelota;
 
     public void MostrarMenuPausa()
     {
@@ -17,6 +17,7 @@ public class MenuPausa : MonoBehaviour
     public void OcultarMenuPausa()
     {
         menuPausa.SetActive(false);
+        if(!pelota.isGameStarted) SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
     }
 
     public void RegresarPantallaPrincipal()

--- a/BreakOut/Assets/Scripts/Pelota.cs
+++ b/BreakOut/Assets/Scripts/Pelota.cs
@@ -54,7 +54,7 @@ public class Pelota : MonoBehaviour
             rigidbody.velocity = velocidadPelota * direccion;
             control.salioArriba = false;
             control.enabled = false;
-            Invoke("HabilitarControl", .1f);
+            Invoke("HabilitarControl", .05f);
         }
 
         //en caso de que la pelota se salga por el borde derecho
@@ -67,7 +67,7 @@ public class Pelota : MonoBehaviour
             rigidbody.velocity = velocidadPelota * direccion;
             control.salioDerecha = false;
             control.enabled = false;
-            Invoke("HabilitarControl", .1f);
+            Invoke("HabilitarControl", .05f);
         }
 
         //en caso de que la pelota se salga por el borde izquierdo
@@ -80,7 +80,7 @@ public class Pelota : MonoBehaviour
             rigidbody.velocity = velocidadPelota * direccion;
             control.salioIzquierda = false;
             control.enabled = false;
-            Invoke("HabilitarControl", .1f);
+            Invoke("HabilitarControl", .05f);
         }
 
         if (Input.GetKeyUp(KeyCode.Space) || Input.GetButton("Submit")) //cuando se use la tecla espacio


### PR DESCRIPTION
Evita que desaparezca la pelota al cerrar el menú de pausa después de mover el slider